### PR TITLE
Prevent duplicate closeCallback calls in case of GC ghosts

### DIFF
--- a/src/CallbackWrapper.php
+++ b/src/CallbackWrapper.php
@@ -107,6 +107,8 @@ class CallbackWrapper extends Wrapper {
 		$result = parent::stream_close();
 		if (is_callable($this->closeCallback)) {
 			call_user_func($this->closeCallback);
+			// prevent further calls by potential PHP 7 GC ghosts
+			$this->closeCallback = null;
 		}
 		return $result;
 	}


### PR DESCRIPTION
Sometimes PHP 7 GC decides to call stream_close again even after the
PHP request has ended, and even if fclose was called before already.

Note: the ghost is even so ghostly that you can't see it with a debugger.
Observed while debugging https://github.com/owncloud/core/issues/22370#issuecomment-263247010

Basically with the log statements from https://github.com/owncloud/core/issues/26735 I can see that `fclose` was called and also the callback was called as well. But **still**, PHP somehow calls it again.

After applying this fix, this specific scenario doesn't cause errors to be logged again.

@icewind1991 