### PR TITLE
Fix read in callbackwrapper

### DIFF
--- a/src/CallbackWrapper.php
+++ b/src/CallbackWrapper.php
@@ -90,7 +90,7 @@ class CallbackWrapper extends Wrapper {
 	public function stream_read($count) {
 		$result = parent::stream_read($count);
 		if (is_callable($this->readCallback)) {
-			call_user_func($this->readCallback, $count);
+			call_user_func($this->readCallback, $result);
 		}
 		return $result;
 	}


### PR DESCRIPTION
The number of read bytes is not the same as the number of bytes
requested to read.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>