### PR TITLE
Add a preClose callback

### DIFF
--- a/src/CallbackWrapper.php
+++ b/src/CallbackWrapper.php
@@ -45,6 +45,11 @@ class CallbackWrapper extends Wrapper {
 	protected $readDirCallBack;
 
 	/**
+	 * @var callable
+	 */
+	protected $preCloseCallback;
+
+	/**
 	 * Wraps a stream with the provided callbacks
 	 *
 	 * @param resource $source
@@ -56,14 +61,15 @@ class CallbackWrapper extends Wrapper {
 	 *
 	 * @throws \BadMethodCallException
 	 */
-	public static function wrap($source, $read = null, $write = null, $close = null, $readDir = null) {
+	public static function wrap($source, $read = null, $write = null, $close = null, $readDir = null, $preClose = null) {
 		$context = stream_context_create(array(
 			'callback' => array(
 				'source' => $source,
 				'read' => $read,
 				'write' => $write,
 				'close' => $close,
-				'readDir' => $readDir
+				'readDir' => $readDir,
+				'preClose' => $preClose,
 			)
 		));
 		return Wrapper::wrapSource($source, $context, 'callback', '\Icewind\Streams\CallbackWrapper');
@@ -76,6 +82,7 @@ class CallbackWrapper extends Wrapper {
 		$this->writeCallback = $context['write'];
 		$this->closeCallback = $context['close'];
 		$this->readDirCallBack = $context['readDir'];
+		$this->preCloseCallback = $context['preClose'];
 		return true;
 	}
 
@@ -104,6 +111,11 @@ class CallbackWrapper extends Wrapper {
 	}
 
 	public function stream_close() {
+		if (is_callable($this->preCloseCallback)) {
+			call_user_func($this->preCloseCallback, $this->loadContext('callback')['source']);
+			// prevent further calls by potential PHP 7 GC ghosts
+			$this->preCloseCallback = null;
+		}
 		$result = parent::stream_close();
 		if (is_callable($this->closeCallback)) {
 			call_user_func($this->closeCallback);

--- a/tests/CallbackWrapperTest.php
+++ b/tests/CallbackWrapperTest.php
@@ -15,10 +15,11 @@ class CallbackWrapperTest extends WrapperTest {
 	 * @param callable $write
 	 * @param callable $close
 	 * @param callable $readDir
+	 * @param callable $preClose
 	 * @return resource
 	 */
-	protected function wrapSource($source, $read = null, $write = null, $close = null, $readDir = null) {
-		return \Icewind\Streams\CallbackWrapper::wrap($source, $read, $write, $close, $readDir);
+	protected function wrapSource($source, $read = null, $write = null, $close = null, $readDir = null, $preClose = null) {
+		return \Icewind\Streams\CallbackWrapper::wrap($source, $read, $write, $close, $readDir, $preClose);
 	}
 
 	/**
@@ -81,6 +82,23 @@ class CallbackWrapperTest extends WrapperTest {
 
 		$wrapped = $this->wrapSource($source, null, null, null, $callBack);
 		readdir($wrapped);
+		$this->assertTrue($called);
+	}
+
+	public function testPreCloseCallback() {
+		$called = false;
+
+		$source = fopen('php://temp', 'r+');
+		fwrite($source, 'foobar');
+		rewind($source);
+
+		$callBack = function ($stream) use (&$called, $source) {
+			$called = true;
+			$this->assertSame($stream, $source);
+		};
+
+		$wrapped = $this->wrapSource($source, null, null, null, null, $callBack);
+		fclose($wrapped);
 		$this->assertTrue($called);
 	}
 }


### PR DESCRIPTION
This is useful in case a callback wants to do something with the stream
right before it gets closed.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>