### PR TITLE
Improve PHPUnit assertions

### DIFF
--- a/tests/CallbackWrapperTest.php
+++ b/tests/CallbackWrapperTest.php
@@ -42,11 +42,11 @@ class CallbackWrapperTest extends WrapperTest {
 		rewind($source);
 
 		$wrapped = $this->wrapSource($source, $callBack);
-		$this->assertEquals('foo', fread($wrapped, 3));
+		$this->assertSame('foo', fread($wrapped, 3));
 		$this->assertTrue($called);
 
-		$this->assertEquals('bar', fread($wrapped, 1000));
-		$this->assertEquals(6, $bytesRead);
+		$this->assertSame('bar', fread($wrapped, 1000));
+		$this->assertSame(6, $bytesRead);
 	}
 
 	public function testWriteCallback() {
@@ -59,7 +59,7 @@ class CallbackWrapperTest extends WrapperTest {
 
 		$wrapped = $this->wrapSource($source, null, $callBack);
 		fwrite($wrapped, 'foobar');
-		$this->assertEquals('foobar', $lastData);
+		$this->assertSame('foobar', $lastData);
 	}
 
 	public function testCloseCallback() {

--- a/tests/CountWrapperTest.php
+++ b/tests/CountWrapperTest.php
@@ -46,7 +46,7 @@ class CountWrapperTest extends WrapperTest {
 
 		stream_get_contents($wrapped);
 		fclose($wrapped);
-		$this->assertEquals(6, $count);
+		$this->assertSame(6, $count);
 	}
 
 	public function testWriteCount() {
@@ -60,6 +60,6 @@ class CountWrapperTest extends WrapperTest {
 
 		fwrite($wrapped, 'foobar');
 		fclose($wrapped);
-		$this->assertEquals(6, $count);
+		$this->assertSame(6, $count);
 	}
 }

--- a/tests/PathWrapper.php
+++ b/tests/PathWrapper.php
@@ -19,6 +19,6 @@ class PathWrapper extends \PHPUnit_Framework_TestCase {
 		$data = 'foobar';
 		$stream = $this->getDataStream($data);
 		$path = \Icewind\Streams\PathWrapper::getPath($stream);
-		$this->assertEquals($data, file_get_contents($path));
+		$this->assertSame($data, file_get_contents($path));
 	}
 }

--- a/tests/SeekableWrapper.php
+++ b/tests/SeekableWrapper.php
@@ -32,11 +32,11 @@ class SeekableWrapper extends \PHPUnit_Framework_TestCase {
 		$source = $this->getSource();
 		$wrapped = $this->wrapSource($source);
 		fseek($wrapped, 6);
-		$this->assertEquals(6, ftell($source));
-		$this->assertEquals(6, ftell($wrapped));
-		$this->assertEquals('ipsum', fread($wrapped, '5'));
+		$this->assertSame(6, ftell($source));
+		$this->assertSame(6, ftell($wrapped));
+		$this->assertSame('ipsum', fread($wrapped, '5'));
 		fseek($wrapped, 6);
-		$this->assertEquals(6, ftell($wrapped));
+		$this->assertSame(6, ftell($wrapped));
 		$this->assertGreaterThan(6, ftell($source));
 	}
 
@@ -45,8 +45,8 @@ class SeekableWrapper extends \PHPUnit_Framework_TestCase {
 		$wrapped = $this->wrapSource($source);
 		fseek($wrapped, 6);
 		fseek($wrapped, 6, SEEK_CUR);
-		$this->assertEquals(12, ftell($source));
-		$this->assertEquals(12, ftell($wrapped));
-		$this->assertEquals('dolor', fread($wrapped, '5'));
+		$this->assertSame(12, ftell($source));
+		$this->assertSame(12, ftell($wrapped));
+		$this->assertSame('dolor', fread($wrapped, '5'));
 	}
 }

--- a/tests/UrlCallback.php
+++ b/tests/UrlCallback.php
@@ -70,7 +70,7 @@ class UrlCallback extends \PHPUnit_Framework_TestCase {
 		$dir = $this->getTempDir() . '/test';
 		$path = \Icewind\Streams\UrlCallback::wrap($dir, null, null, $callback);
 		mkdir($path);
-		$this->assertTrue(file_exists($dir));
+		$this->assertFileExists($dir);
 		$this->assertTrue($called);
 	}
 
@@ -83,7 +83,7 @@ class UrlCallback extends \PHPUnit_Framework_TestCase {
 		mkdir($dir);
 		$path = \Icewind\Streams\UrlCallback::wrap($dir, null, null, null, null, $callback);
 		rmdir($path);
-		$this->assertFalse(file_exists($dir));
+		$this->assertFileNotExists($dir);
 		$this->assertTrue($called);
 	}
 
@@ -97,7 +97,7 @@ class UrlCallback extends \PHPUnit_Framework_TestCase {
 		$path = \Icewind\Streams\UrlCallback::wrap($source, null, null, null, $callback);
 		$target = $path->wrapPath($source . '_rename');
 		rename($path, $target);
-		$this->assertTrue(file_exists($source . '_rename'));
+		$this->assertFileExists($source . '_rename');
 		$this->assertTrue($called);
 	}
 
@@ -110,7 +110,7 @@ class UrlCallback extends \PHPUnit_Framework_TestCase {
 		touch($file);
 		$path = \Icewind\Streams\UrlCallback::wrap($file, null, null, null, null, null, $callback);
 		unlink($path);
-		$this->assertFalse(file_exists($file));
+		$this->assertFileNotExists($file);
 		$this->assertTrue($called);
 	}
 
@@ -134,6 +134,6 @@ class UrlCallback extends \PHPUnit_Framework_TestCase {
 		$dir = $this->getTempDir() . '/test/sad';
 		$path = \Icewind\Streams\UrlCallback::wrap($dir);
 		mkdir($path, 0700, true);
-		$this->assertTrue(file_exists($dir));
+		$this->assertFileExists($dir);
 	}
 }

--- a/tests/WrapperTest.php
+++ b/tests/WrapperTest.php
@@ -20,9 +20,9 @@ abstract class WrapperTest extends \PHPUnit_Framework_TestCase {
 		rewind($source);
 
 		$wrapped = $this->wrapSource($source);
-		$this->assertEquals('foo', fread($wrapped, 3));
-		$this->assertEquals('bar', fread($wrapped, 3));
-		$this->assertEquals('', fread($wrapped, 3));
+		$this->assertSame('foo', fread($wrapped, 3));
+		$this->assertSame('bar', fread($wrapped, 3));
+		$this->assertSame('', fread($wrapped, 3));
 	}
 
 	public function testWrite() {
@@ -31,9 +31,9 @@ abstract class WrapperTest extends \PHPUnit_Framework_TestCase {
 
 		$wrapped = $this->wrapSource($source);
 
-		$this->assertEquals(6, fwrite($wrapped, 'foobar'));
+		$this->assertSame(6, fwrite($wrapped, 'foobar'));
 		rewind($source);
-		$this->assertEquals('foobar', stream_get_contents($source));
+		$this->assertSame('foobar', stream_get_contents($source));
 	}
 
 	public function testClose() {
@@ -53,19 +53,19 @@ abstract class WrapperTest extends \PHPUnit_Framework_TestCase {
 
 		$wrapped = $this->wrapSource($source);
 
-		$this->assertEquals(0, ftell($wrapped));
+		$this->assertSame(0, ftell($wrapped));
 
 		fseek($wrapped, 2);
-		$this->assertEquals(2, ftell($source));
-		$this->assertEquals(2, ftell($wrapped));
+		$this->assertSame(2, ftell($source));
+		$this->assertSame(2, ftell($wrapped));
 
 		fseek($wrapped, 2, SEEK_CUR);
-		$this->assertEquals(4, ftell($source));
-		$this->assertEquals(4, ftell($wrapped));
+		$this->assertSame(4, ftell($source));
+		$this->assertSame(4, ftell($wrapped));
 
 		fseek($wrapped, -1, SEEK_END);
-		$this->assertEquals(5, ftell($source));
-		$this->assertEquals(5, ftell($wrapped));
+		$this->assertSame(5, ftell($source));
+		$this->assertSame(5, ftell($wrapped));
 	}
 
 	public function testStat() {
@@ -84,7 +84,7 @@ abstract class WrapperTest extends \PHPUnit_Framework_TestCase {
 		$wrapped = $this->wrapSource($source);
 
 		ftruncate($wrapped, 2);
-		$this->assertEquals('fo', fread($wrapped, 10));
+		$this->assertSame('fo', fread($wrapped, 10));
 	}
 
 	public function testLock() {
@@ -130,10 +130,10 @@ abstract class WrapperTest extends \PHPUnit_Framework_TestCase {
 
 		$source = opendir(__DIR__);
 		$wrapped = $this->wrapSource($source);
-		$this->assertEquals($content[0], readdir($wrapped));
-		$this->assertEquals($content[1], readdir($wrapped));
-		$this->assertEquals($content[2], readdir($wrapped));
+		$this->assertSame($content[0], readdir($wrapped));
+		$this->assertSame($content[1], readdir($wrapped));
+		$this->assertSame($content[2], readdir($wrapped));
 		rewinddir($wrapped);
-		$this->assertEquals($content[0], readdir($wrapped));
+		$this->assertSame($content[0], readdir($wrapped));
 	}
 }


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to make value equals assertion strict.
- Using the `assertFileExists` and `assertFileNotExists` to assert file is existed/non-existed.