### PR TITLE
Add mode parameter to wrapSource

### DIFF
--- a/src/WrapperHandler.php
+++ b/src/WrapperHandler.php
@@ -57,7 +57,7 @@ class WrapperHandler {
 	 * @param string|null $class deprecated, class is now automatically generated
 	 * @return bool|resource
 	 */
-	protected static function wrapSource($source, $context = [], $protocol = null, $class = null) {
+	protected static function wrapSource($source, $context = [], $protocol = null, $class = null, $mode = 'r+') {
 		if ($class === null) {
 			$class = static::class;
 		}
@@ -72,7 +72,7 @@ class WrapperHandler {
 			if (self::isDirectoryHandle($source)) {
 				return opendir($protocol . '://', $context);
 			} else {
-				return fopen($protocol . '://', 'r+', false, $context);
+				return fopen($protocol . '://', $mode, false, $context);
 			}
 		} finally {
 			stream_wrapper_unregister($protocol);


### PR DESCRIPTION
Allow passing the mode in the wrapSource signature to avoid declaration errors when extending from the class in the Nextcloud encryption code:

https://github.com/nextcloud/server/blob/73c7d0dc8156703341733b9c39c69d05263173da/lib/private/Files/Stream/Encryption.php#L203

Should resole https://github.com/nextcloud/server/issues/26464