### PR TITLE
Fix return type of wrap method to resource|false instead of resource|bool

### DIFF
--- a/src/CallbackWrapper.php
+++ b/src/CallbackWrapper.php
@@ -58,7 +58,7 @@ class CallbackWrapper extends Wrapper {
 	 * @param callable|null $close (optional)
 	 * @param callable|null $readDir (optional)
 	 * @param callable|null $preClose (optional)
-	 * @return resource|bool
+	 * @return resource|false
 	 *
 	 */
 	public static function wrap($source, $read = null, $write = null, $close = null, $readDir = null, $preClose = null) {

--- a/src/CountWrapper.php
+++ b/src/CountWrapper.php
@@ -55,7 +55,7 @@ class CountWrapper extends Wrapper {
 	 *
 	 * @param resource $source
 	 * @param callable $callback
-	 * @return resource|bool
+	 * @return resource|false
 	 *
 	 * @throws \BadMethodCallException
 	 */

--- a/src/DirectoryFilter.php
+++ b/src/DirectoryFilter.php
@@ -46,7 +46,7 @@ class DirectoryFilter extends DirectoryWrapper {
 	/**
 	 * @param resource $source
 	 * @param callable $filter
-	 * @return resource|bool
+	 * @return resource|false
 	 */
 	public static function wrap($source, callable $filter) {
 		return self::wrapSource($source, [

--- a/src/HashWrapper.php
+++ b/src/HashWrapper.php
@@ -41,7 +41,7 @@ abstract class HashWrapper extends Wrapper {
 	 * @param resource $source
 	 * @param string $hash
 	 * @param callable $callback
-	 * @return resource|bool
+	 * @return resource|false
 	 *
 	 * @throws \BadMethodCallException
 	 */

--- a/src/IteratorDirectory.php
+++ b/src/IteratorDirectory.php
@@ -92,7 +92,7 @@ class IteratorDirectory extends WrapperHandler implements Directory {
 	 * Creates a directory handle from the provided array or iterator
 	 *
 	 * @param \Iterator | array $source
-	 * @return resource|bool
+	 * @return resource|false
 	 *
 	 * @throws \BadMethodCallException
 	 */

--- a/src/WrapperHandler.php
+++ b/src/WrapperHandler.php
@@ -55,7 +55,7 @@ class WrapperHandler {
 	 * @param resource|array $context
 	 * @param string|null $protocol deprecated, protocol is now automatically generated
 	 * @param string|null $class deprecated, class is now automatically generated
-	 * @return bool|resource
+	 * @return resource|false
 	 */
 	protected static function wrapSource($source, $context = [], $protocol = null, $class = null, $mode = 'r+') {
 		if ($class === null) {


### PR DESCRIPTION
This avoids having to handle a not-possible true value in the calling methods and will help tidying typing on nextcloud/server side.